### PR TITLE
Automatically create results directory if it does not already exist.

### DIFF
--- a/SPARQL_endpoint_analysis/conf_generator_and_va_readiness_score.ipynb
+++ b/SPARQL_endpoint_analysis/conf_generator_and_va_readiness_score.ipynb
@@ -6,6 +6,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from pathlib import Path\n",
     "import conf_generator"
    ]
   },
@@ -15,7 +16,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "conf_generator.set_path(\"example/UNESCO/\")"
+    "Path(\"example/UNESCO/results\").mkdir(parents=True, exist_ok=True)"
    ]
   },
   {
@@ -24,12 +25,21 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "entities_dictionary = conf_generator.generate_entities(store_results=False)"
+    "conf_generator.set_path(\"example/UNESCO\")"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "entities_dictionary = conf_generator.generate_entities(store_results=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -38,7 +48,7 @@
        "11801"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -49,7 +59,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -58,7 +68,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -67,7 +77,7 @@
        "38"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -78,7 +88,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -87,7 +97,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -114,7 +124,7 @@
        " 'virtual_assistant_readiness_score': 0.58160994384954}"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -140,7 +150,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Hi @mariaangelapellegrino this patch simply creates the `results` directory if one does not already exist. You can view the change as follows
```
from pathlib import Path
...
Path("example/UNESCO/results").mkdir(parents=True, exist_ok=True)
```